### PR TITLE
added support to return similarity of strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 var arr = [];
 var charCodeCache = [];
 
-module.exports = function (a, b) {
+module.exports = function (a, b, asPercent) {
 	if (a === b) {
 		return 0;
 	}
@@ -44,5 +44,5 @@ module.exports = function (a, b) {
 		}
 	}
 
-	return ret;
+	return asPercent ? 1 - (ret / Math.max(aLen, bLen)) : ret;
 };


### PR DESCRIPTION
Added asPercentage parameter to return similarity of two given input.

It is useful to see how similar two strings are for some cases.

"abc" and "abd" differs only by one operation. This one operation is %33.3 of the content of the longest string.

"this is some long text to see how much nonsense I can produce" and "this is some long text to see how much nonsense I cam produce" also differs only by one operation. On this case one operation is only %1.7 of the content of the longest string.

I've once used percentages to find a string (comes from ICR) in a predefined list.
