### PR TITLE
Add `talisman` library to benchmark

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -7,6 +7,7 @@ var ld = require('ld').computeDistance;
 var levdist = require('levdist');
 var natural = require('natural').LevenshteinDistance;
 var levenshtein = require('levenshtein');
+var talisman = require('talisman/metrics/distance/levenshtein');
 var leven = require('./');
 
 function run(fn) {
@@ -57,5 +58,9 @@ suite('leven', function () {
 
 	bench('levenshtein', function () {
 		run(levenshtein);
+	});
+
+	bench('talisman', function () {
+		run(talisman);
 	});
 });

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "levenshtein-edit-distance": "^2.0.0",
     "matcha": "^0.7.0",
     "natural": "^0.4.0",
+    "talisman": "^0.16.0",
     "xo": "^0.16.0"
   }
 }


### PR DESCRIPTION
Hello @sindresorhus. I stumbled upon you library today & I was really impressed by the performance of your function. So I tried to combine some of your techniques with other optimizations I had already written for the Levenshtein distance of the [Talisman](https://github.com/Yomguithereal/talisman) library and this is the benchmark result I got:

```
         338,141 op/s » leven
         303,109 op/s » levenshtein-edit-distance
         224,503 op/s » fast-levenshtein
          22,678 op/s » levenshtein-component
          21,810 op/s » levdist
          23,136 op/s » ld
          19,789 op/s » natural
          12,356 op/s » levenshtein
         407,765 op/s » talisman
```

I believe the improvement comes from the prefix & suffix trimming in linear time as well as some other less significant gimmicks.

If you want, I can create a PR to add those improvements to your code as I believe your function can still be more performant than mine since you only handle strings while I need to handle arbitrary sequences as well.

Have a good day.