### PR TITLE
Implementing linear time suffix trimming

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ module.exports = function (a, b) {
 
 	var swap = a;
 
+	// Swapping the strings if a is longer than b so we know which one is the
+	// shortest & which one is the longest.
 	if (a.length > b.length) {
 		a = b;
 		b = swap;
@@ -26,6 +28,10 @@ module.exports = function (a, b) {
 		return aLen;
 	}
 
+	// Performing suffix trimming:
+	// We can linearly drop suffix common to both strings since they
+	// don't increase distance at all.
+	// Note: `~-` is the bitwise way to perform a `- 1` operation.
 	while (aLen > 0 && (a.charCodeAt(~-aLen) === b.charCodeAt(~-bLen))) {
 		aLen--;
 		bLen--;

--- a/index.js
+++ b/index.js
@@ -8,6 +8,13 @@ module.exports = function (a, b) {
 		return 0;
 	}
 
+	var swap = a;
+
+	if (a.length > b.length) {
+		a = b;
+		b = swap;
+	}
+
 	var aLen = a.length;
 	var bLen = b.length;
 
@@ -17,6 +24,15 @@ module.exports = function (a, b) {
 
 	if (bLen === 0) {
 		return aLen;
+	}
+
+	while (aLen > 0 && (a.charCodeAt(~-aLen) === b.charCodeAt(~-bLen))) {
+		aLen--;
+		bLen--;
+	}
+
+	if (aLen === 0) {
+		return bLen;
 	}
 
 	var bCharCode;

--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ module.exports = function (a, b) {
 
 	var swap = a;
 
-	// Swapping the strings if a is longer than b so we know which one is the
-	// shortest & which one is the longest.
+	// Swapping the strings if `a` is longer than `b` so we know which one is the
+	// shortest & which one is the longest
 	if (a.length > b.length) {
 		a = b;
 		b = swap;
@@ -30,8 +30,8 @@ module.exports = function (a, b) {
 
 	// Performing suffix trimming:
 	// We can linearly drop suffix common to both strings since they
-	// don't increase distance at all.
-	// Note: `~-` is the bitwise way to perform a `- 1` operation.
+	// don't increase distance at all
+	// Note: `~-` is the bitwise way to perform a `- 1` operation
 	while (aLen > 0 && (a.charCodeAt(~-aLen) === b.charCodeAt(~-bLen))) {
 		aLen--;
 		bLen--;


### PR DESCRIPTION
Hello again @sindresorhus. This PR adds linear time suffix trimming to your function. This should give you an edge (at least it did on the benchmark I ran), but I advise you run your own just to be sure (maybe with more use cases and swapping the strings already present).

The idea is to trim the suffix of both strings linearly until they start to differ.

The strange `~-` operation used here is the bitwise way to perform a `-1` operation on a number. It speeds up the computation a bit on my benchmarks.

I can also implement prefix trimming but while writing this PR, I noticed that I did something wrong and my prefix trimming is actually erroneous so I need to fix it. However, since it means performing some more arithmetical operations, I fear it could slow down things rather than improving the performance of the function. I will come back later when my function is fixed to tell you if it's worth it to add prefix trimming then.

Have a nice day.