### PR TITLE
Add `maxDistance` option

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -29,13 +29,10 @@ const strings = [
 ];
 
 /**
- *
- * @param {Function} fn The function to run.
- * @param {Array|undefined} preArgs An array of arguments to apply before the
- * `left` and `right` arguments when calling `fn`.
- * @param {Array|undefined} postArgs An array of elements to apply after the
- * `left` and `right` arguments when calling `fn`.
- */
+@param {Function} fn - The function to run.
+@param {Array | undefined} preArgs - An array of arguments to apply before the `left` and `right` arguments when calling `fn`.
+@param {Array | undefined} postArgs - An array of elements to apply after the `left` and `right` arguments when calling `fn`.
+*/
 function run(fn, preArgs, postArgs) {
 	const hasPreArgs = Array.isArray(preArgs);
 	const hasPostArgs = Array.isArray(postArgs);
@@ -112,4 +109,3 @@ suite('leven', () => {
 		run(natural);
 	});
 });
-

--- a/bench.js
+++ b/bench.js
@@ -10,27 +10,41 @@ const levenshtein = require('levenshtein');
 const talisman = require('talisman/metrics/distance/levenshtein');
 const leven = require('.');
 
-function run(fn) {
-	fn('a', 'b');
-	fn('ab', 'ac');
-	fn('ac', 'bc');
-	fn('abc', 'axc');
-	fn('kitten', 'sitting');
-	fn('xabxcdxxefxgx', '1ab2cd34ef5g6');
-	fn('cat', 'cow');
-	fn('xabxcdxxefxgx', 'abcdefg');
-	fn('javawasneat', 'scalaisgreat');
-	fn('example', 'samples');
-	fn('sturgeon', 'urgently');
-	fn('levenshtein', 'frankenstein');
-	fn('distance', 'difference');
-	fn('因為我是中國人所以我會說中文', '因為我是英國人所以我會說英文');
-	fn('Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.', 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.');
+const strings = [
+	['a', 'b'],
+	['ab', 'ac'],
+	['ac', 'bc'],
+	['abc', 'axc'],
+	['kitten', 'sitting'],
+	['xabxcdxxefxgx', '1ab2cd34ef5g6'],
+	['cat', 'cow'],
+	['xabxcdxxefxgx', 'abcdefg'],
+	['javawasneat', 'scalaisgreat'],
+	['example', 'samples'],
+	['sturgeon', 'urgently'],
+	['levenshtein', 'frankenstein'],
+	['distance', 'difference'],
+	['I know not all that may be coming, but be it what it will, I\'ll go to it laughing', 'short'],
+	['Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.', 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.']
+]
+
+function run(fn, ...args) {
+	strings.forEach(([left, right]) => {
+		fn(left, right, ...args)
+	})
 }
 
 suite('leven', () => {
 	bench('leven', () => {
 		run(leven);
+	});
+
+	bench('leven with maxDistance:5', () => {
+		run(leven, {maxDistance: 5})
+	});
+
+	bench('leven with maxDistance:10', () => {
+		run(leven, {maxDistance: 10})
 	});
 
 	bench('talisman', () => {

--- a/bench.js
+++ b/bench.js
@@ -37,15 +37,21 @@ const strings = [
  * `left` and `right` arguments when calling `fn`.
  */
 function run(fn, preArgs, postArgs) {
-	const hasPreArgs = Array.isArray(preArgs)
-	const hasPostArgs = Array.isArray(postArgs)
+	const hasPreArgs = Array.isArray(preArgs);
+	const hasPostArgs = Array.isArray(postArgs);
 
 	strings.forEach(([left, right]) => {
-		let args = []
-		if (hasPreArgs) args = args.concat(...preArgs);
+		let args = [];
+		if (hasPreArgs) {
+			args = args.concat(...preArgs);
+		}
+
 		args = args.concat(left, right);
-		if (hasPostArgs) args = args.concat(...postArgs);
-		fn(...args)
+		if (hasPostArgs) {
+			args = args.concat(...postArgs);
+		}
+
+		fn(...args);
 	});
 }
 

--- a/bench.js
+++ b/bench.js
@@ -26,12 +26,12 @@ const strings = [
 	['distance', 'difference'],
 	['I know not all that may be coming, but be it what it will, I\'ll go to it laughing', 'short'],
 	['Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.', 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.']
-]
+];
 
 function run(fn, ...args) {
 	strings.forEach(([left, right]) => {
-		fn(left, right, ...args)
-	})
+		fn(left, right, ...args);
+	});
 }
 
 suite('leven', () => {
@@ -40,11 +40,11 @@ suite('leven', () => {
 	});
 
 	bench('leven with maxDistance:5', () => {
-		run(leven, {maxDistance: 5})
+		run(leven, {maxDistance: 5});
 	});
 
 	bench('leven with maxDistance:10', () => {
-		run(leven, {maxDistance: 10})
+		run(leven, {maxDistance: 10});
 	});
 
 	bench('talisman', () => {

--- a/bench.js
+++ b/bench.js
@@ -28,9 +28,24 @@ const strings = [
 	['Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.', 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.']
 ];
 
-function run(fn, ...args) {
+/**
+ *
+ * @param {Function} fn The function to run.
+ * @param {Array|undefined} preArgs An array of arguments to apply before the
+ * `left` and `right` arguments when calling `fn`.
+ * @param {Array|undefined} postArgs An array of elements to apply after the
+ * `left` and `right` arguments when calling `fn`.
+ */
+function run(fn, preArgs, postArgs) {
+	const hasPreArgs = Array.isArray(preArgs)
+	const hasPostArgs = Array.isArray(postArgs)
+
 	strings.forEach(([left, right]) => {
-		fn(left, right, ...args);
+		let args = []
+		if (hasPreArgs) args = args.concat(...preArgs);
+		args = args.concat(left, right);
+		if (hasPostArgs) args = args.concat(...postArgs);
+		fn(...args)
 	});
 }
 
@@ -39,16 +54,28 @@ suite('leven', () => {
 		run(leven);
 	});
 
-	bench('leven with maxDistance:5', () => {
-		run(leven, {maxDistance: 5});
+	bench('leven maxDistance:5', () => {
+		run(leven, undefined, [{maxDistance: 5}]);
 	});
 
-	bench('leven with maxDistance:10', () => {
-		run(leven, {maxDistance: 10});
+	bench('leven maxDistance:10', () => {
+		run(leven, undefined, [{maxDistance: 10}]);
 	});
 
 	bench('talisman', () => {
 		run(talisman);
+	});
+
+	bench('talisman.limited', () => {
+		run(talisman.limited, [Infinity]);
+	});
+
+	bench('talisman.limited maxDistance:5', () => {
+		run(talisman.limited, [5]);
+	});
+
+	bench('talisman.limited maxDistance:10', () => {
+		run(talisman.limited, [10]);
 	});
 
 	bench('levenshtein-edit-distance', () => {
@@ -79,3 +106,4 @@ suite('leven', () => {
 		run(natural);
 	});
 });
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,27 @@
+interface Options {
+	/**
+	When `maxDistance` is supplied, leven will return the value of `maxDistance`
+	if the calculated Levenshtein distance is greater than `maxDistance`.
+
+	Additionally, leven will determine if calculating the Levenshtein distance is
+	necessary by comparing the difference in string length between `left` and
+	`right` to `maxDistance`, which may lead to an increase of performance in your
+	application.
+
+	@example
+	```
+	import leven = require('leven');
+
+	leven('breathtaking', 'car', {maxDistance: 4});
+	//=> 4
+
+	leven('breathtaking', 'car');
+	//=> 11
+	```
+	 */
+	readonly maxDistance?: number
+}
+
 declare const leven: {
 	/**
 	Measure the difference between two strings.
@@ -10,7 +34,7 @@ declare const leven: {
 	//=> 2
 	```
 	*/
-	(left: string, right: string, options?: any): number;
+	(left: string, right: string, options?: Options): number;
 
 	// TODO: Remove this for the next major release, refactor the whole definition to:
 	// declare function leven(left: string, right: string): number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,9 @@
 interface Options {
 	/**
-	When `maxDistance` is supplied, leven will return the value of `maxDistance`
-	if the calculated Levenshtein distance is greater than `maxDistance`.
+	When true, Leven will return the value of `maxDistance` if the calculated Levenshtein distance is greater than `maxDistance`.
 
-	Additionally, leven will determine if calculating the Levenshtein distance is
-	necessary by comparing the difference in string length between `left` and
-	`right` to `maxDistance`, which may lead to an increase of performance in your
-	application.
+	Additionally, Leven will determine if calculating the Levenshtein distance is necessary by comparing the difference in string length between `left` and
+	`right` to `maxDistance`, which may lead to an increase of performance in your app.
 
 	@example
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare const leven: {
 	//=> 2
 	```
 	*/
-	(left: string, right: string): number;
+	(left: string, right: string, options?: any): number;
 
 	// TODO: Remove this for the next major release, refactor the whole definition to:
 	// declare function leven(left: string, right: string): number;

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const leven = (left, right, options) => {
 		return 0;
 	}
 
+	const maxDistance = (options && options.maxDistance) || Number.POSITIVE_INFINITY;
 	const swap = left;
 
 	// Swapping the strings if `a` is longer than `b` so we know which one is the
@@ -21,10 +22,8 @@ const leven = (left, right, options) => {
 
 	// Short circuit if the difference in lengths is greater than or equal to the
 	// specified maxDistance
-	if (options && options.maxDistance) {
-		if (Math.abs(leftLength - rightLength) >= options.maxDistance) {
-			return options.maxDistance;
-		}
+	if (Math.abs(leftLength - rightLength) >= maxDistance) {
+		return maxDistance;
 	}
 
 	// Performing suffix trimming:
@@ -77,7 +76,7 @@ const leven = (left, right, options) => {
 		}
 	}
 
-	return result;
+	return result >= maxDistance ? maxDistance : result;
 };
 
 module.exports = leven;

--- a/index.js
+++ b/index.js
@@ -19,11 +19,11 @@ const leven = (left, right, options) => {
 	let leftLength = left.length;
 	let rightLength = right.length;
 
-	// Short circuit if the difference in lengths is greater than or equal
-	// to the specified maximumDistance
-	if (options && options.maximumDistance) {
-		if (Math.abs(leftLength - rightLength) >= options.maximumDistance) {
-			return options.maximumDistance;
+	// Short circuit if the difference in lengths is greater than or equal to the
+	// specified maxDistance
+	if (options && options.maxDistance) {
+		if (Math.abs(leftLength - rightLength) >= options.maxDistance) {
+			return options.maxDistance;
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const array = [];
 const charCodeCache = [];
 
-const leven = (left, right) => {
+const leven = (left, right, options) => {
 	if (left === right) {
 		return 0;
 	}
@@ -18,6 +18,14 @@ const leven = (left, right) => {
 
 	let leftLength = left.length;
 	let rightLength = right.length;
+
+	// Short circuit if the difference in lengths is greater than or equal
+	// to the specified maximumDistance
+	if (options && options.maximumDistance) {
+		if (Math.abs(leftLength - rightLength) >= options.maximumDistance) {
+			return options.maximumDistance;
+		}
+	}
 
 	// Performing suffix trimming:
 	// We can linearly drop suffix common to both strings since they

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,3 +2,5 @@ import {expectType} from 'tsd';
 import leven = require('.');
 
 expectType<number>(leven('kitten', 'sitting'));
+expectType<number>(leven('kitten', 'sitting', {}));
+expectType<number>(leven('kitten', 'sitting', {maxDistance: 4}));

--- a/test.js
+++ b/test.js
@@ -16,7 +16,10 @@ test('main', t => {
 	t.is(leven('levenshtein', 'frankenstein'), 6);
 	t.is(leven('distance', 'difference'), 5);
 	t.is(leven('因為我是中國人所以我會說中文', '因為我是英國人所以我會說英文'), 2);
-	t.is(leven('123', '12345678', {fakeValue: 1}), 5);
-	t.is(leven('123', '12345678', {maxDistance: 3}), 3);
-	t.is(leven('123', '12345678', {maxDistance: 6}), 5);
+});
+
+test('options.maxDistance', t => {
+	t.is(leven('hippopotamus', 'fox', {maxDistance: 7}), 7);
+	t.is(leven('extraterrestrial', 'catch', {maxDistance: 5}), 5);
+	t.is(leven('attitude', 'medicine', {maxDistance: 4}), 4);
 });

--- a/test.js
+++ b/test.js
@@ -16,4 +16,7 @@ test('main', t => {
 	t.is(leven('levenshtein', 'frankenstein'), 6);
 	t.is(leven('distance', 'difference'), 5);
 	t.is(leven('因為我是中國人所以我會說中文', '因為我是英國人所以我會說英文'), 2);
+	t.is(leven('123', '12345678', {fakeValue: 1}), 5);
+	t.is(leven('123', '12345678', {maximumDistance: 3}), 3);
+	t.is(leven('123', '12345678', {maximumDistance: 6}), 5);
 });

--- a/test.js
+++ b/test.js
@@ -17,6 +17,6 @@ test('main', t => {
 	t.is(leven('distance', 'difference'), 5);
 	t.is(leven('因為我是中國人所以我會說中文', '因為我是英國人所以我會說英文'), 2);
 	t.is(leven('123', '12345678', {fakeValue: 1}), 5);
-	t.is(leven('123', '12345678', {maximumDistance: 3}), 3);
-	t.is(leven('123', '12345678', {maximumDistance: 6}), 5);
+	t.is(leven('123', '12345678', {maxDistance: 3}), 3);
+	t.is(leven('123', '12345678', {maxDistance: 6}), 5);
 });


### PR DESCRIPTION
> When `maxDistance` is supplied, leven will return the value of `maxDistance` if the calculated Levenshtein distance is greater than `maxDistance`.
>Additionally, leven will determine if calculating the Levenshtein distance is necessary by comparing the difference in string length between `left` and `right` to `maxDistance`, which may lead to an increase of performance in your application.

#### Benchmark

leven takes a performance hit, but in applications where maxDistance is utilized, performance can be boosted.

```
  90,002 op/s » leven
 221,391 op/s » leven with maxDistance:5
 118,272 op/s » leven with maxDistance:10
  94,685 op/s » talisman
     674 op/s » levenshtein-edit-distance
     445 op/s » fast-levenshtein
     391 op/s » levenshtein-component
     105 op/s » ld
```

Fixes #14  
Replaces and Closes #15