### PR TITLE
Update benchmarks

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -231,7 +231,7 @@ const sentences = [
 	'The beach was crowded with snow leopards.',
 	'Your girlfriend bought your favorite cookie crisp cereal but forgot to get milk.',
 	'I love eating toasted cheese and tuna sandwiches.',
-	'Wisdom is easily acqui                       be called a beach if there was no sand.',
+	'Check back tomorrow; I will see if the book has arrived.',
 	'He was the type of guy who liked Christmas lights on his house in the middle of July.',
 	'As the years pass by, we all know owners look more and more like their dogs.',
 	'The shark-infested South Pine channel was the only way in or out.',

--- a/bench.js
+++ b/bench.js
@@ -36,7 +36,7 @@ function paragraphBench(fn) {
 	}
 }
 
-suite('100 words, length max=15 min=5 avr=8.4', () => {
+suite('50 words, length max=15 min=5 avr=8.4', () => {
 	bench('fastest-levenshtein', () => {
 		wordBench(distance);
 	});
@@ -231,8 +231,7 @@ const sentences = [
 	'The beach was crowded with snow leopards.',
 	'Your girlfriend bought your favorite cookie crisp cereal but forgot to get milk.',
 	'I love eating toasted cheese and tuna sandwiches.',
-	'Wisdom is easily acquired when hiding under the bed with a saucepan on your head.',
-	'He wondered if it could be called a beach if there was no sand.',
+	'Wisdom is easily acqui                       be called a beach if there was no sand.',
 	'He was the type of guy who liked Christmas lights on his house in the middle of July.',
 	'As the years pass by, we all know owners look more and more like their dogs.',
 	'The shark-infested South Pine channel was the only way in or out.',

--- a/bench.js
+++ b/bench.js
@@ -8,60 +8,257 @@ const levdist = require('levdist');
 const natural = require('natural').LevenshteinDistance;
 const levenshtein = require('levenshtein');
 const talisman = require('talisman/metrics/distance/levenshtein');
+const {distance} = require('fastest-levenshtein');
+const jsLevenshtein = require('js-levenshtein');
 const leven = require('.');
 
-function run(fn) {
-	fn('a', 'b');
-	fn('ab', 'ac');
-	fn('ac', 'bc');
-	fn('abc', 'axc');
-	fn('kitten', 'sitting');
-	fn('xabxcdxxefxgx', '1ab2cd34ef5g6');
-	fn('cat', 'cow');
-	fn('xabxcdxxefxgx', 'abcdefg');
-	fn('javawasneat', 'scalaisgreat');
-	fn('example', 'samples');
-	fn('sturgeon', 'urgently');
-	fn('levenshtein', 'frankenstein');
-	fn('distance', 'difference');
-	fn('因為我是中國人所以我會說中文', '因為我是英國人所以我會說英文');
-	fn('Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.', 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.');
+function wordBench(fn) {
+	for (let i = 0; i + 1 < words.length; i += 2) {
+		const w1 = words[i];
+		const w2 = words[i + 1];
+		fn(w1, w2);
+	}
 }
 
-suite('leven', () => {
-	bench('leven', () => {
-		run(leven);
-	});
+function sentenceBench(fn) {
+	for (let i = 0; i + 1 < sentences.length; i += 2) {
+		const s1 = sentences[i];
+		const s2 = sentences[i + 1];
+		fn(s1, s2);
+	}
+}
 
-	bench('talisman', () => {
-		run(talisman);
-	});
+function paragraphBench(fn) {
+	for (let i = 0; i + 1 < paragraphs.length; i += 2) {
+		const p1 = paragraphs[i];
+		const p2 = paragraphs[i + 1];
+		fn(p1, p2);
+	}
+}
 
-	bench('levenshtein-edit-distance', () => {
-		run(levenshteinEditDistance);
+suite('100 words, length max=15 min=5 avr=8.4', () => {
+	bench('fastest-levenshtein', () => {
+		wordBench(distance);
 	});
 
 	bench('fast-levenshtein', () => {
-		run(fastLevenshtein);
+		wordBench(fastLevenshtein);
+	});
+
+	bench('js-levenshtein', () => {
+		wordBench(jsLevenshtein);
+	});
+
+	bench('leven', () => {
+		wordBench(leven);
+	});
+
+	bench('talisman', () => {
+		wordBench(talisman);
+	});
+
+	bench('levenshtein-edit-distance', () => {
+		wordBench(levenshteinEditDistance);
 	});
 
 	bench('levenshtein-component', () => {
-		run(levenshteinComponent);
+		wordBench(levenshteinComponent);
 	});
 
 	bench('ld', () => {
-		run(ld);
+		wordBench(ld);
 	});
 
 	bench('levenshtein', () => {
-		run(levenshtein);
+		wordBench(levenshtein);
 	});
 
 	bench('levdist', () => {
-		run(levdist);
+		wordBench(levdist);
 	});
 
 	bench('natural', () => {
-		run(natural);
+		wordBench(natural);
 	});
 });
+
+suite('20 sentences, length max=106 min=30 avr=64.4', () => {
+	bench('fastest-levenshtein', () => {
+		sentenceBench(distance);
+	});
+
+	bench('fast-levenshtein', () => {
+		sentenceBench(fastLevenshtein);
+	});
+
+	bench('js-levenshtein', () => {
+		sentenceBench(jsLevenshtein);
+	});
+
+	bench('leven', () => {
+		sentenceBench(leven);
+	});
+
+	bench('talisman', () => {
+		sentenceBench(talisman);
+	});
+
+	bench('levenshtein-edit-distance', () => {
+		sentenceBench(levenshteinEditDistance);
+	});
+
+	bench('levenshtein-component', () => {
+		sentenceBench(levenshteinComponent);
+	});
+
+	bench('ld', () => {
+		sentenceBench(ld);
+	});
+
+	bench('levenshtein', () => {
+		sentenceBench(levenshtein);
+	});
+
+	bench('levdist', () => {
+		sentenceBench(levdist);
+	});
+
+	bench('natural', () => {
+		sentenceBench(natural);
+	});
+});
+
+suite('10 paragraphs, length max=565 min=186 avr=340', () => {
+	bench('fastest-levenshtein', () => {
+		paragraphBench(distance);
+	});
+
+	bench('fast-levenshtein', () => {
+		paragraphBench(fastLevenshtein);
+	});
+
+	bench('js-levenshtein', () => {
+		paragraphBench(jsLevenshtein);
+	});
+
+	bench('leven', () => {
+		paragraphBench(leven);
+	});
+
+	bench('talisman', () => {
+		paragraphBench(talisman);
+	});
+
+	bench('levenshtein-edit-distance', () => {
+		paragraphBench(levenshteinEditDistance);
+	});
+
+	bench('levenshtein-component', () => {
+		paragraphBench(levenshteinComponent);
+	});
+
+	bench('ld', () => {
+		paragraphBench(ld);
+	});
+
+	bench('levenshtein', () => {
+		paragraphBench(levenshtein);
+	});
+
+	bench('levdist', () => {
+		paragraphBench(levdist);
+	});
+
+	bench('natural', () => {
+		paragraphBench(natural);
+	});
+});
+
+const words = [
+	'vizierate',
+	'lyophilizing',
+	'bucklered',
+	'gonglike',
+	'moperies',
+	'regales',
+	'sublates',
+	'expecter',
+	'implorers',
+	'whump',
+	'candygram',
+	'beblooding',
+	'parceled',
+	'pledgor',
+	'elegiac',
+	'agnates',
+	'narrowed',
+	'dewlapped',
+	'sensationally',
+	'distal',
+	'demijohn',
+	'myxamoebae',
+	'eosin',
+	'buckets',
+	'parvis',
+	'ticcing',
+	'uncaged',
+	'cantors',
+	'superstructural',
+	'drowse',
+	'autoimmune',
+	'echinoid',
+	'interschool',
+	'scrumptious',
+	'legionnaire',
+	'kwanza',
+	'gallicas',
+	'joying',
+	'cobras',
+	'slinkinesses',
+	'nubilous',
+	'sandlings',
+	'moldinesses',
+	'glutaraldehydes',
+	'align',
+	'upreach',
+	'remotions',
+	'scotches',
+	'killed',
+	'poleyns'
+];
+
+const sentences = [
+	'The beach was crowded with snow leopards.',
+	'Your girlfriend bought your favorite cookie crisp cereal but forgot to get milk.',
+	'I love eating toasted cheese and tuna sandwiches.',
+	'Wisdom is easily acquired when hiding under the bed with a saucepan on your head.',
+	'He wondered if it could be called a beach if there was no sand.',
+	'He was the type of guy who liked Christmas lights on his house in the middle of July.',
+	'As the years pass by, we all know owners look more and more like their dogs.',
+	'The shark-infested South Pine channel was the only way in or out.',
+	'She tilted her head back and let whip cream stream into her mouth while taking a bath.',
+	'He had unknowingly taken up sleepwalking as a nighttime hobby.',
+	'He wasn\'t bitter that she had moved on but from the radish.',
+	'I am never at home on Sundays.',
+	'Each person who knows you has a different perception of who you are.',
+	'She was too short to see over the fence.',
+	'Let me help you with your baggage.',
+	'He realized there had been several deaths on this road, but his concern rose when he saw the exact number.',
+	'She had some amazing news to share but nobody to share it with.',
+	'Buried deep in the snow, he hoped his batteries were fresh in his avalanche beacon.',
+	'There are no heroes in a punk rock band.',
+	'The snow-covered path was no help in finding his way out of the back-country.'
+];
+
+const paragraphs = [
+	'A long black shadow slid across the pavement near their feet and the five Venusians, very much startled, looked overhead. They were barely in time to see the huge gray form of the carnivore before it vanished behind a sign atop a nearby building which bore the mystifying information "Pepsi-Cola.',
+	'The boy walked down the street in a carefree way, playing without notice of what was about him. He didn\'t hear the sound of the car as his ball careened into the road. He took a step toward it, and in doing so sealed his fate.',
+	'He was aware there were numerous wonders of this world including the unexplained creations of humankind that showed the wonder of our ingenuity. There are huge heads on Easter Island. There are the Egyptian pyramids. There’s Stonehenge. But he now stood in front of a newly discovered monument that simply didn\'t make any sense and he wondered how he was ever going to be able to explain it.',
+	'Greg understood that this situation would make Michael terribly uncomfortable. Michael simply had no idea what was about to come and even though Greg could prevent it from happening, he opted to let it happen. It was quite ironic, really. It was something Greg had said he would never wish upon anyone a million times, yet here he was knowingly letting it happen to one of his best friends. He rationalized that it would ultimately make Michael a better person and that no matter how uncomfortable, everyone should experience racism at least once in their lifetime.',
+	'Balloons are pretty and come in different colors, different shapes, different sizes, and they can even adjust sizes as needed. But don\'t make them too big or they might just pop, and then bye-bye balloon. It\'ll be gone and lost for the rest of mankind. They can serve a variety of purposes, from decorating to water balloon wars. You just have to use your head to think a little bit about what to do with them.',
+	'She was in a hurry. Not the standard hurry when you\'re in a rush to get someplace, but a frantic hurry. The type of hurry where a few seconds could mean life or death. She raced down the road ignoring speed limits and weaving between cars. She was only a few minutes away when traffic came to a dead standstill on the road ahead.',
+	'The box sat on the desk next to the computer. It had arrived earlier in the day and business had interrupted her opening it earlier. She didn\'t who had sent it and briefly wondered who it might have been. As she began to unwrap it, she had no idea that opening it would completely change her life.',
+	'She counted. One. She could hear the steps coming closer. Two. Puffs of breath could be seen coming from his mouth. Three. He stopped beside her. Four. She pulled the trigger of the gun.',
+	'It was a question of which of the two she preferred. On the one hand, the choice seemed simple. The more expensive one with a brand name would be the choice of most. It was the easy choice. The safe choice. But she wasn\'t sure she actually preferred it.',
+	'Green vines attached to the trunk of the tree had wound themselves toward the top of the canopy. Ants used the vine as their private highway, avoiding all the creases and crags of the bark, to freely move at top speed from top to bottom or bottom to top depending on their current chore. At least this was the way it was supposed to be. Something had damaged the vine overnight halfway up the tree leaving a gap in the once pristine ant highway.'
+];

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
 	],
 	"devDependencies": {
 		"ava": "^1.4.1",
-		"fast-levenshtein": "^2.0.6",
+		"fast-levenshtein": "^3.0.0",
+		"fastest-levenshtein": "^1.0.10",
+		"js-levenshtein": "^1.1.6",
 		"ld": "^0.1.0",
 		"levdist": "^2.2.9",
 		"levenshtein": "^1.0.5",

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # leven [![Build Status](https://travis-ci.org/sindresorhus/leven.svg?branch=master)](https://travis-ci.org/sindresorhus/leven)
 
 > Measure the difference between two strings<br>
-> One of the fastest JS implementations of the [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) algorithm
+> Implementation of the [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) algorithm
 
 
 ## Install
@@ -28,15 +28,43 @@ $ npm run bench
 ```
 
 ```
-         165,926 op/s » leven
-         164,398 op/s » talisman
-           1,044 op/s » levenshtein-edit-distance
-             628 op/s » fast-levenshtein
-             497 op/s » levenshtein-component
-             195 op/s » ld
-             190 op/s » levenshtein
-             168 op/s » levdist
-              10 op/s » natural
+         476,628 op/s » fastest-levenshtein
+         427,831 op/s » fast-levenshtein
+         171,965 op/s » js-levenshtein
+         136,828 op/s » leven
+         130,892 op/s » talisman
+         134,643 op/s » levenshtein-edit-distance
+          71,828 op/s » levenshtein-component
+          42,189 op/s » ld
+          32,185 op/s » levenshtein
+          27,428 op/s » levdist
+           4,014 op/s » natural
+
+                      20 sentences, length max=106 min=30 avr=64.4
+          49,949 op/s » fastest-levenshtein
+          48,797 op/s » fast-levenshtein
+           8,871 op/s » js-levenshtein
+           5,295 op/s » leven
+           5,812 op/s » talisman
+           4,920 op/s » levenshtein-edit-distance
+           2,867 op/s » levenshtein-component
+           1,582 op/s » ld
+           1,651 op/s » levenshtein
+           1,376 op/s » levdist
+             190 op/s » natural
+
+                      10 paragraphs, length max=565 min=186 avr=340
+           3,578 op/s » fastest-levenshtein
+           3,439 op/s » fast-levenshtein
+             583 op/s » js-levenshtein
+             355 op/s » leven
+             374 op/s » talisman
+             341 op/s » levenshtein-edit-distance
+             189 op/s » levenshtein-component
+              91 op/s » ld
+             102 op/s » levenshtein
+              89 op/s » levdist
+               5 op/s » natural
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ $ npm run bench
 ```
 
 ```
+                      50 words, length max=15 min=5 avr=8.4
          476,628 op/s » fastest-levenshtein
          427,831 op/s » fast-levenshtein
          171,965 op/s » js-levenshtein


### PR DESCRIPTION
The benchmarks in the `readme.md` are quite old and are far from being representative of real-world usage. This PR improves the benchmarks (inspired by the benchmarks found in the `js-levenshtein` repo) and updates `fast-levenshtein` to the newest version 3.0.0. Furthermore, `js-levenshtein` and [`fastest-levenshtein`](https://github.com/ka-weihe/fastest-levenshtein) have been added to the benchmarks.

I also suggest changing the about-section.  